### PR TITLE
Replace deprecated optparse with argparse

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-"""usage: %prog [options] filename
-
+"""
 Parse a document to a tree, with optional profiling
 """
 
+import argparse
 import sys
 import traceback
-from optparse import OptionParser
 
 from html5lib import html5parser
 from html5lib import treebuilders, serializer, treewalkers
@@ -15,12 +14,12 @@ from html5lib import _utils
 
 
 def parse():
-    optParser = getOptParser()
-    opts, args = optParser.parse_args()
+    parser = get_parser()
+    opts = parser.parse_args()
     encoding = "utf8"
 
     try:
-        f = args[-1]
+        f = opts.filename
         # Try opening from the internet
         if f.startswith('http://'):
             try:
@@ -151,92 +150,84 @@ def printOutput(parser, document, opts):
         sys.stdout.write("\nParse errors:\n" + "\n".join(errList) + "\n")
 
 
-def getOptParser():
-    parser = OptionParser(usage=__doc__)
+def get_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
 
-    parser.add_option("-p", "--profile", action="store_true", default=False,
-                      dest="profile", help="Use the hotshot profiler to "
-                      "produce a detailed log of the run")
+    parser.add_argument("-p", "--profile", action="store_true",
+                        help="Use the hotshot profiler to "
+                        "produce a detailed log of the run")
 
-    parser.add_option("-t", "--time",
-                      action="store_true", default=False, dest="time",
-                      help="Time the run using time.time (may not be accurate on all platforms, especially for short runs)")
+    parser.add_argument("-t", "--time",
+                        action="store_true",
+                        help="Time the run using time.time (may not be accurate on all platforms, especially for short runs)")
 
-    parser.add_option("-b", "--treebuilder", action="store", type="string",
-                      dest="treebuilder", default="etree")
+    parser.add_argument("-b", "--treebuilder",
+                        default="etree")
 
-    parser.add_option("-e", "--error", action="store_true", default=False,
-                      dest="error", help="Print a list of parse errors")
+    parser.add_argument("-e", "--error", action="store_true",
+                        help="Print a list of parse errors")
 
-    parser.add_option("-f", "--fragment", action="store_true", default=False,
-                      dest="fragment", help="Parse as a fragment")
+    parser.add_argument("-f", "--fragment", action="store_true",
+                        help="Parse as a fragment")
 
-    parser.add_option("-s", "--scripting", action="store_true", default=False,
-                      dest="scripting", help="Handle noscript tags as if scripting was enabled")
+    parser.add_argument("-s", "--scripting", action="store_true",
+                        help="Handle noscript tags as if scripting was enabled")
 
-    parser.add_option("", "--tree", action="store_true", default=False,
-                      dest="tree", help="Output as debug tree")
+    parser.add_argument("--tree", action="store_true",
+                        help="Output as debug tree")
 
-    parser.add_option("-x", "--xml", action="store_true", default=False,
-                      dest="xml", help="Output as xml")
+    parser.add_argument("-x", "--xml", action="store_true",
+                        help="Output as xml")
 
-    parser.add_option("", "--no-html", action="store_false", default=True,
-                      dest="html", help="Don't output html")
+    parser.add_argument("--no-html", action="store_false",
+                        dest="html", help="Don't output html")
 
-    parser.add_option("-c", "--encoding", action="store_true", default=False,
-                      dest="encoding", help="Print character encoding used")
+    parser.add_argument("-c", "--encoding", action="store_true",
+                        help="Print character encoding used")
 
-    parser.add_option("", "--inject-meta-charset", action="store_true",
-                      default=False, dest="inject_meta_charset",
-                      help="inject <meta charset>")
+    parser.add_argument("--inject-meta-charset", action="store_true",
+                        help="inject <meta charset>")
 
-    parser.add_option("", "--strip-whitespace", action="store_true",
-                      default=False, dest="strip_whitespace",
-                      help="strip whitespace")
+    parser.add_argument("--strip-whitespace", action="store_true",
+                        help="strip whitespace")
 
-    parser.add_option("", "--omit-optional-tags", action="store_true",
-                      default=False, dest="omit_optional_tags",
-                      help="omit optional tags")
+    parser.add_argument("--omit-optional-tags", action="store_true",
+                        help="omit optional tags")
 
-    parser.add_option("", "--quote-attr-values", action="store_true",
-                      default=False, dest="quote_attr_values",
-                      help="quote attribute values")
+    parser.add_argument("--quote-attr-values", action="store_true",
+                        help="quote attribute values")
 
-    parser.add_option("", "--use-best-quote-char", action="store_true",
-                      default=False, dest="use_best_quote_char",
-                      help="use best quote character")
+    parser.add_argument("--use-best-quote-char", action="store_true",
+                        help="use best quote character")
 
-    parser.add_option("", "--quote-char", action="store",
-                      default=None, dest="quote_char",
-                      help="quote character")
+    parser.add_argument("--quote-char",
+                        help="quote character")
 
-    parser.add_option("", "--no-minimize-boolean-attributes",
-                      action="store_false", default=True,
-                      dest="minimize_boolean_attributes",
-                      help="minimize boolean attributes")
+    parser.add_argument("--no-minimize-boolean-attributes",
+                        action="store_false",
+                        dest="minimize_boolean_attributes",
+                        help="minimize boolean attributes")
 
-    parser.add_option("", "--use-trailing-solidus", action="store_true",
-                      default=False, dest="use_trailing_solidus",
-                      help="use trailing solidus")
+    parser.add_argument("--use-trailing-solidus", action="store_true",
+                        help="use trailing solidus")
 
-    parser.add_option("", "--space-before-trailing-solidus",
-                      action="store_true", default=False,
-                      dest="space_before_trailing_solidus",
-                      help="add space before trailing solidus")
+    parser.add_argument("--space-before-trailing-solidus",
+                        action="store_true",
+                        help="add space before trailing solidus")
 
-    parser.add_option("", "--escape-lt-in-attrs", action="store_true",
-                      default=False, dest="escape_lt_in_attrs",
-                      help="escape less than signs in attribute values")
+    parser.add_argument("--escape-lt-in-attrs", action="store_true",
+                        help="escape less than signs in attribute values")
 
-    parser.add_option("", "--escape-rcdata", action="store_true",
-                      default=False, dest="escape_rcdata",
-                      help="escape rcdata element values")
+    parser.add_argument("--escape-rcdata", action="store_true",
+                        help="escape rcdata element values")
 
-    parser.add_option("", "--sanitize", action="store_true", default=False,
-                      dest="sanitize", help="sanitize")
+    parser.add_argument("--sanitize", action="store_true",
+                        help="sanitize")
 
-    parser.add_option("-l", "--log", action="store_true", default=False,
-                      dest="log", help="log state transitions")
+    parser.add_argument("-l", "--log", action="store_true",
+                        help="log state transitions")
+
+    parser.add_argument("filename")
 
     return parser
 


### PR DESCRIPTION
> https://docs.python.org/3/library/optparse.html
> 
> > Deprecated since version 3.2: The optparse module is deprecated and
> > will not be developed further; development will continue with the
> > argparse module.