### PR TITLE
Deploy to PyPI from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
       tags: false
       repo: html5lib/html5lib-python
       branch: master
-      condition: $TOXENV = lint
+      condition: "$TOXENV = py36-base"
     user: __token__
     password:
       secure: "TODO"
@@ -49,7 +49,7 @@ deploy:
       tags: true
       repo: html5lib/html5lib-python
       branch: master
-      condition: "$TOXENV = lint"
+      condition: "$TOXENV = py36-base"
     user: __token__
     password:
       secure: "TODO"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,21 +36,21 @@ deploy:
     server: https://test.pypi.org/legacy/
     on:
       tags: false
-      repo: html5lib/html5lib-python
+      repo: html5lib-python/html5lib-python
       branch: master
-      python: "3.6"
+      python: "3.8"
       condition: "$TOXENV = base"
     user: __token__
     password:
-      secure: "TODO"
+      secure: "bbdWoIryZgPlGfLhJsT2zfoVV4bjdPXICbsu8tkE4v4nG3Xr7hrLDhXK359Wkinrtx44GS4G4J5nLa3XTXgbVtR6E2WfUauWS6mg2AczGzgpYZaSBmNX+W6v97DB1vLuTmKRxuS4OSWTmI9Cjn1QKTCjG3rQ6LgjROaJEYLYP1KfZHnI2Nlzw6bRCxfHaqnmg4izsuqZsWVK2lOgw391NzP0wzqgOiaG2zxWbMdqNiEXkYk6bGr+48CGOd5cvLqrowZSSGCOQelsjmjswjl91j56NluMIf/3D1B8h172INzTCfOw067U9RKPkLNdHQC+owEett4B6iW57yUkXoxh+71cJVeXcEdLvcjktgeBLXlbjSo44ADrw8guQNIQthJUKpHOdFn9ypPXRQ2VS8LC/xX0/uvfpcPvxDhX25zVmXTimWFNFWwz3UceNyMU1EXFcIxejkMlW13CKYQfu2AyxPbvZ8IM0j8Y7T4B6vZ7CDmBoFZUW7SQYNqBua/zPxH3ThSXN7I9anhLmAt6oq4FH8osgbymrWq5BFX6fTxfpahd/xePfguK9IgBBcJTR49rlou5fhwQAiITqtGG3Q2ZhrQtkvIBjJCiZUussIJmMpHefM+xY1GwS6rAWpYI2k8hqtE3z31VLDywBProkupNscwLlDZsn1E7lynaJhFjVz0="
     distributions: sdist --format=gztar bdist_wheel
     skip_existing: true
   - provider: pypi
     on:
       tags: true
-      repo: html5lib/html5lib-python
+      repo: html5lib-python/html5lib-python
       branch: master
-      python: "3.6"
+      python: "3.8"
       condition: "$TOXENV = base"
     user: __token__
     password:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ deploy:
       tags: false
       repo: html5lib/html5lib-python
       branch: master
-      condition: "$TOXENV = py36-base"
+      python: "3.6"
+      condition: "$TOXENV = base"
     user: __token__
     password:
       secure: "TODO"
@@ -49,7 +50,8 @@ deploy:
       tags: true
       repo: html5lib/html5lib-python
       branch: master
-      condition: "$TOXENV = py36-base"
+      python: "3.6"
+      condition: "$TOXENV = base"
     user: __token__
     password:
       secure: "TODO"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,29 @@ after_script:
   - python debug-info.py
 
 after_success:
-  - codecov
+- codecov
+
+deploy:
+  - provider: pypi
+    server: https://test.pypi.org/legacy/
+    on:
+      tags: false
+      repo: html5lib/html5lib-python
+      branch: master
+      condition: $TOXENV = lint
+    user: __token__
+    password:
+      secure: "TODO"
+    distributions: sdist --format=gztar bdist_wheel
+    skip_existing: true
+  - provider: pypi
+    on:
+      tags: true
+      repo: html5lib/html5lib-python
+      branch: master
+      condition: "$TOXENV = lint"
+    user: __token__
+    password:
+      secure: "TODO"
+    distributions: sdist --format=gztar bdist_wheel
+    skip_existing: true


### PR DESCRIPTION
> This should help make releasing easier.
> 
> * Deploy non-tagged builds to Test PyPI
> * Deploy tagged builds to live PyPI
> 
> Will only trigger when run from the `html5lib/html5lib-python` repo, so not for forks.
> 
> TODO:
> 
> 1. Add an API token called (say) `html5lib-ci` at [test.pypi.org/manage/account/token](https://test.pypi.org/manage/account/token/)
> 2. On the command line, install the [Travis Client](https://github.com/travis-ci/travis.rb#installation)
> 3. Run `travis encrypt`
> 4. Paste in the token from step 1, it begins `pypi-`
> 5. Ctrl-D to end
> 6. Add the encrypted value as the `password: secure: "TODO"` value on line 53
> 7. Repeat for production PyPI, put the encrypted value on line 64
> 
> More info on PyPI API tokens: [pypi.org/help/#apitoken](https://pypi.org/help/#apitoken)

https://github.com/html5lib/html5lib-python/pull/430

Updated to add TestPyPI API token for html5lib-python/html5lib-python.
